### PR TITLE
Create custom GTM event for category selection

### DIFF
--- a/age-spread.html
+++ b/age-spread.html
@@ -86,7 +86,11 @@ secondarymenu: "false"
 <script>
   window.addEventListener('load', function(){
     document.getElementById('categories').addEventListener('change', function(e){
-        window.location.hash = e.target.value;
+      dataLayer.push({
+        'event': 'selection-change',
+        'selected': e.target.value
+      });
+      window.location.hash = e.target.value;
     });
   });
 </script>

--- a/gender-gap.html
+++ b/gender-gap.html
@@ -85,7 +85,11 @@ secondarymenu: "false"
 <script>
   window.addEventListener('load', function(){
     document.getElementById('categories').addEventListener('change', function(e){
-        window.location.hash = e.target.value;
+      dataLayer.push({
+        'event': 'selection-change',
+        'selected': e.target.value
+      });
+      window.location.hash = e.target.value;
     });
   });
 </script>

--- a/income-divide.html
+++ b/income-divide.html
@@ -87,7 +87,11 @@ secondarymenu: "false"
 <script>
   window.addEventListener('load', function(){
     document.getElementById('categories').addEventListener('change', function(e){
-        window.location.hash = e.target.value;
+      dataLayer.push({
+        'event': 'selection-change',
+        'selected': e.target.value
+      });
+      window.location.hash = e.target.value;
     });
   });
 </script>

--- a/municipality.html
+++ b/municipality.html
@@ -86,7 +86,11 @@ secondarymenu: "false"
 <script>
   window.addEventListener('load', function(){
     document.getElementById('categories').addEventListener('change', function(e){
-        window.location.hash = e.target.value;
+      dataLayer.push({
+        'event': 'selection-change',
+        'selected': e.target.value
+      });
+      window.location.hash = e.target.value;
     });
   });
 </script>

--- a/trends-over-time.html
+++ b/trends-over-time.html
@@ -86,7 +86,11 @@ secondarymenu: "false"
 <script>
   window.addEventListener('load', function(){
     document.getElementById('categories').addEventListener('change', function(e){
-        window.location.hash = e.target.value;
+      dataLayer.push({
+        'event': 'selection-change',
+        'selected': e.target.value
+      });
+      window.location.hash = e.target.value;
     });
   });
 </script>


### PR DESCRIPTION
To allow tracking interactions with the category selection box, push data to Google Tag Manager when the input changes.